### PR TITLE
display.platform needs `inkplate6` not `inkplate`

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -104,7 +104,7 @@ font:
 
 
 display:
-- platform: inkplate
+- platform: inkplate6
   id: inkplate_display
   greyscale: false
   partial_updating: false


### PR DESCRIPTION
binary will not compile with `inkplate`.

Fixes https://github.com/jesserockz/esphome-inkplate/issues/3